### PR TITLE
[wrapper] Correctly detect lib64 in rpmlint.wrapper. Fixes JB#56364

### DIFF
--- a/rpmlint-mini.changes
+++ b/rpmlint-mini.changes
@@ -1,3 +1,6 @@
+* Mon Nov 15 2021 Niels Breet <niels.breet@jolla.com> - 2.0.0+git2
+- Correctly detect lib64 in rpmlint.wrapper. Fixes JB#56364
+
 * Fri Jun 11 2021 Matti Lehtimäki <matti.lehtimaki@jolla.com> - 2.0.0+git1
 - Adapt to new rpmlint. JB#54636
 

--- a/rpmlint-mini.spec
+++ b/rpmlint-mini.spec
@@ -14,7 +14,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-magic
 BuildRequires:  libtool
 Summary:        Rpm correctness checker
-Version:        2.0.0+git1
+Version:        2.0.0+git2
 Release:        1
 Url:            https://github.com/rpm-software-management/rpmlint
 License:        GPLv2+

--- a/rpmlint.wrapper
+++ b/rpmlint.wrapper
@@ -2,7 +2,7 @@
 # Allow arbitrary installation
 # Default must be /opt/testing to work with obs build
 BASE=${SA_ROOT:-/opt/testing}
-if test -d ${BASE}/lib64; then
+if test -d ${BASE}/usr/lib64; then
 	LD_LIBRARY_PATH=${BASE}/usr/lib64
 else
 	LD_LIBRARY_PATH=${BASE}/usr/lib


### PR DESCRIPTION
Signed-off-by: Niels Breet <niels.breet@jolla.com>